### PR TITLE
Feat: Add landmarks to db and map screen UI

### DIFF
--- a/app/src/main/java/ca/uwaterloo/treklogue/MainActivity.kt
+++ b/app/src/main/java/ca/uwaterloo/treklogue/MainActivity.kt
@@ -17,8 +17,9 @@ import ca.uwaterloo.treklogue.data.repository.LandmarkRealmSyncRepository
 import ca.uwaterloo.treklogue.data.repository.UserRealmSyncRepository
 import ca.uwaterloo.treklogue.ui.Router
 import ca.uwaterloo.treklogue.ui.UserEvent
-import ca.uwaterloo.treklogue.ui.login.LoginActivity
 import ca.uwaterloo.treklogue.ui.UserViewModel
+import ca.uwaterloo.treklogue.ui.login.LoginActivity
+import ca.uwaterloo.treklogue.ui.map.MapViewModel
 import ca.uwaterloo.treklogue.ui.theme.MyApplicationTheme
 import kotlinx.coroutines.launch
 
@@ -81,6 +82,9 @@ class MainActivity : ComponentActivity() {
     }
 
     private val userViewModel: UserViewModel by viewModels()
+    private val mapViewModel: MapViewModel by viewModels {
+        MapViewModel.factory(landmarkRepository, this)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -93,8 +97,10 @@ class MainActivity : ComponentActivity() {
                             startActivity(Intent(this@MainActivity, LoginActivity::class.java))
                             finish()
                         }
+
                         is UserEvent.Info ->
                             Log.e(TAG(), userEvent.message)
+
                         is UserEvent.Error ->
                             Log.e(TAG(), "${userEvent.message}: ${userEvent.throwable.message}")
                     }
@@ -103,7 +109,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             MyApplicationTheme {
-                Router(userViewModel)
+                Router(userViewModel, mapViewModel)
             }
         }
     }

--- a/app/src/main/java/ca/uwaterloo/treklogue/data/model/Landmark.kt
+++ b/app/src/main/java/ca/uwaterloo/treklogue/data/model/Landmark.kt
@@ -8,10 +8,12 @@ class Landmark() : RealmObject {
     @PrimaryKey
     var _id: ObjectId = ObjectId()
     var name: String = ""
-    var location: String = "" // Can be modified to be a real geographical location object later
+    var latitude: Double = 0.0
+    var longitude: Double = 0.0
 
-    constructor(name: String = "", location: String = "") : this() {
+    constructor(name: String, latitude: Double, longitude: Double) : this() {
         this.name = name
-        this.location = location
+        this.latitude = latitude
+        this.longitude = longitude
     }
 }

--- a/app/src/main/java/ca/uwaterloo/treklogue/ui/Router.kt
+++ b/app/src/main/java/ca/uwaterloo/treklogue/ui/Router.kt
@@ -18,12 +18,14 @@ import ca.uwaterloo.treklogue.ui.composables.Screens
 import ca.uwaterloo.treklogue.ui.list.ListScreen
 import ca.uwaterloo.treklogue.ui.list.ListViewModel
 import ca.uwaterloo.treklogue.ui.map.MapScreen
+import ca.uwaterloo.treklogue.ui.map.MapViewModel
 import ca.uwaterloo.treklogue.ui.profile.ProfileScreen
 import ca.uwaterloo.treklogue.ui.settings.SettingsScreen
 
 @Composable
 fun Router(
     userViewModel: UserViewModel,
+    mapViewModel: MapViewModel
 ) {
     val navigationController = rememberNavController()
     val selectedTab = remember {
@@ -57,7 +59,8 @@ fun Router(
         ) {
             composable(route = Screens.Map.screen) {
                 MapScreen(
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
+                    mapViewModel
                 )
             }
 

--- a/app/src/main/java/ca/uwaterloo/treklogue/ui/UserViewModel.kt
+++ b/app/src/main/java/ca/uwaterloo/treklogue/ui/UserViewModel.kt
@@ -5,8 +5,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch

--- a/app/src/main/java/ca/uwaterloo/treklogue/ui/map/MapScreen.kt
+++ b/app/src/main/java/ca/uwaterloo/treklogue/ui/map/MapScreen.kt
@@ -13,11 +13,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import ca.uwaterloo.treklogue.R
+import ca.uwaterloo.treklogue.data.model.Landmark
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.CameraPositionState
@@ -48,16 +51,13 @@ fun MapScreen(
         position = defaultCameraPosition
     }
 
-    for (landmark in mapViewModel.state.value.landmarks) {
-        Log.v(null, "LANDMARK: " + landmark.name + " " + landmark.latitude + " " + landmark.longitude)
-    }
-
     Box(modifier) {
         GoogleMapView(
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(),
             cameraPositionState = cameraPositionState,
+            landmarks = mapViewModel.state.value.landmarks,
             //onMapLoaded = {}
         )
         FloatingActionButton(
@@ -80,6 +80,7 @@ fun MapScreen(
 fun GoogleMapView(
     modifier: Modifier = Modifier,
     cameraPositionState: CameraPositionState,
+    landmarks: SnapshotStateList<Landmark>
     //onMapLoaded: () -> Unit
 ) {
     val mapUiSettings by remember {
@@ -94,6 +95,13 @@ fun GoogleMapView(
         position = waterlooLocation
     )
 
+    for (landmark in landmarks) {
+        Log.v(
+            null,
+            "LANDMARK: " + landmark.name + " " + landmark.latitude + " " + landmark.longitude
+        )
+    }
+
     GoogleMap(
         modifier = modifier,
         cameraPositionState = cameraPositionState,
@@ -104,5 +112,19 @@ fun GoogleMapView(
             state = locationState,
             draggable = true
         )
+        for (landmark in landmarks) {
+            LandmarkMarker(LatLng(landmark.latitude, landmark.longitude), landmark.name)
+        }
     }
+}
+
+@Composable
+fun LandmarkMarker(position: LatLng, title: String) {
+    val markerState = rememberMarkerState(null, position)
+    Marker(
+        state = markerState,
+        title = title,
+        snippet = title, // TODO: Can include landmark description in the future
+        icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE)
+    )
 }

--- a/app/src/main/java/ca/uwaterloo/treklogue/ui/map/MapScreen.kt
+++ b/app/src/main/java/ca/uwaterloo/treklogue/ui/map/MapScreen.kt
@@ -1,5 +1,6 @@
 package ca.uwaterloo.treklogue.ui.map
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,10 +41,15 @@ val defaultCameraPosition = CameraPosition.fromLatLngZoom(waterlooLocation, 8f)
 
 @Composable
 fun MapScreen(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    mapViewModel: MapViewModel
 ) {
     val cameraPositionState = rememberCameraPositionState {
         position = defaultCameraPosition
+    }
+
+    for (landmark in mapViewModel.state.value.landmarks) {
+        Log.v(null, "LANDMARK: " + landmark.name + " " + landmark.latitude + " " + landmark.longitude)
     }
 
     Box(modifier) {

--- a/app/src/main/java/ca/uwaterloo/treklogue/ui/map/MapViewModel.kt
+++ b/app/src/main/java/ca/uwaterloo/treklogue/ui/map/MapViewModel.kt
@@ -1,0 +1,112 @@
+package ca.uwaterloo.treklogue.ui.map
+
+import android.os.Bundle
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.savedstate.SavedStateRegistryOwner
+import ca.uwaterloo.treklogue.data.model.Landmark
+import ca.uwaterloo.treklogue.data.repository.LandmarkRealmSyncRepository
+import io.realm.kotlin.notifications.InitialResults
+import io.realm.kotlin.notifications.ResultsChange
+import io.realm.kotlin.notifications.UpdatedResults
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Types of UX events triggered by user actions.
+ */
+sealed class MapEvent {
+
+    class Error(val message: String, val throwable: Throwable) : MapEvent()
+
+}
+
+/**
+ * UI representation of a screen state.
+ */
+data class MapState(
+    val landmarks: SnapshotStateList<Landmark>
+) {
+    companion object {
+        val initialState = MapState(landmarks = mutableStateListOf())
+    }
+}
+
+class MapViewModel(
+    private val landmarkRepository: LandmarkRealmSyncRepository
+) : ViewModel() {
+
+    private val _state: MutableState<MapState> = mutableStateOf(MapState.initialState)
+    val state: State<MapState>
+        get() = _state
+
+    private val _event: MutableSharedFlow<MapEvent> = MutableSharedFlow()
+    val event: Flow<MapEvent>
+        get() = _event
+
+    init {
+        viewModelScope.launch {
+            landmarkRepository.getLandmarkList().collect { event: ResultsChange<Landmark> ->
+                when (event) {
+                    is InitialResults -> {
+                        _state.value.landmarks.clear()
+                        _state.value.landmarks.addAll(event.list)
+                    }
+
+                    is UpdatedResults -> {
+                        if (event.deletions.isNotEmpty() && _state.value.landmarks.isNotEmpty()) {
+                            event.deletions.reversed().forEach {
+                                _state.value.landmarks.removeAt(it)
+                            }
+                        }
+                        if (event.insertions.isNotEmpty()) {
+                            event.insertions.forEach {
+                                _state.value.landmarks.add(it, event.list[it])
+                            }
+                        }
+                        if (event.changes.isNotEmpty()) {
+                            event.changes.forEach {
+                                _state.value.landmarks.removeAt(it)
+                                _state.value.landmarks.add(it, event.list[it])
+                            }
+                        }
+                    }
+
+                    else -> Unit // No-op
+                }
+            }
+        }
+    }
+
+    fun error(errorEvent: MapEvent.Error) {
+        viewModelScope.launch {
+            _event.emit(errorEvent)
+        }
+    }
+
+    companion object {
+        fun factory(
+            repository: LandmarkRealmSyncRepository,
+            owner: SavedStateRegistryOwner,
+            defaultArgs: Bundle? = null
+        ): AbstractSavedStateViewModelFactory {
+            return object : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
+                override fun <T : ViewModel> create(
+                    key: String,
+                    modelClass: Class<T>,
+                    handle: SavedStateHandle
+                ): T {
+                    return MapViewModel(repository) as T
+                }
+            }
+        }
+    }
+}

--- a/citations.md
+++ b/citations.md
@@ -1,2 +1,3 @@
 * Clean Architecture starter code: https://git.uwaterloo.ca/cs346/public/1241/slides/-/tree/main/06-04-ui-patterns/clean-android-ui
 * Template app provided by MongoDB Atlas: https://www.mongodb.com/docs/atlas/app-services/reference/template-apps/#std-label-template-apps
+* Maps Compose Library: https://developers.google.com/maps/documentation/android-sdk/maps-compose

--- a/timelog.md
+++ b/timelog.md
@@ -22,3 +22,4 @@
 | 2024/02/27 | 0      | 5     | 0       | 0       | 0     | 0       | Changing Navigation Bar UI                                  |
 | 2024/02/27 | 0      | 0     | 0       | 0       | 0     | 5.5     | Finish on List UI + navigation from list to detail entry    |
 | 2024/02/27 | 1.5    | 0     | 0       | 0       | 0     | 0       | Review 3 PRs, code clean up and refactoring                 |
+| 2024/03/02 | 3      | 0     | 0       | 0       | 0     | 0       | Add landmarks to db and map screen UI                       |


### PR DESCRIPTION
* Updated the schema for a Landmark
  * Now each Landmark record is composed of: `_id`, `name`, `latitude`, and `longitude`
* Added a few mock Landmarks to our database (https://cloud.mongodb.com/v2/65c952d2cde54b7266a52479#/metrics/replicaSet/65c95332807dea2a953955d8/explorer/dev/Landmark/find)
* Added a composable for the marker representing each landmark on the map
* Added `MapViewModel`, which will fetch the list of all landmarks on init